### PR TITLE
docs: clarify install options and add Windows guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ openspec init
 
 ### 2) Import Into Your Project
 
+Choose **one** of the following options.
+
+#### Option A (Manual)
+
 Copy this repository into your project first, so the `docs/` and `ai-specs/` paths already exist when you configure OpenSpec:
 
 ```bash
@@ -81,13 +85,16 @@ Copy this repository into your project first, so the `docs/` and `ai-specs/` pat
 cp -rn lidr-specboot/* your-project/
 ```
 
-Alternative for step 2 (Claude Code users):
+#### Option B (Claude Code users)
 
-- You can alternatively install the Claude plugin and use it as the coding agent for this import step.
-- This only changes **how** you install Specboot. It does **not** install OpenSpec, does **not** update OpenSpec config, and does **not** customize `docs/`.
+If you use Claude Code, you can use the Specboot installer instead of copying the files manually.
 
-Quick install:
+- It only changes **how** Specboot is imported into your project.
+- It does **not** install OpenSpec.
+- It does **not** update the OpenSpec configuration.
+- It does **not** customize `docs/`.
 
+Quick install - From the root directory of your project, open a terminal and run:
 ```bash
 npx @lidr/lidr-specboot
 ```

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ More manual than a single cp -rn, but it's the only reliable path on Windows tod
 
 </details> 
 
+> **Note — don't canonicalize OpenSpec's own skills into `ai-specs/`**
+>
+> `openspec init` (Step 1) generates the `openspec-*` skills (`openspec-propose`, `openspec-apply-change`, `openspec-archive-change`, `openspec-explore`, `openspec-sync-specs`) and writes them **directly** into the agent folders (`.claude/skills/`, `.cursor/skills/`, `.github/skills/`); `openspec update` regenerates them there. They are **not** part of Specboot's `ai-specs/` skill set — their front-matter says `author: openspec`, not `author: LIDR.co`.
+>
+> So when you canonicalize skills into `ai-specs/skills/` and recreate the symlinks above, do it **only for Specboot's own skills**. Do **not** copy or symlink the `openspec-*` skills into `ai-specs/`: a copy there is never executed (the agent runs the CLI-managed one) and silently drifts out of version as the CLI updates the real files. Quick check after install — every folder under `ai-specs/skills/` should be `author: LIDR.co`; any `author: openspec` entry is a stray to remove.
+
 #### Option B (Claude Code users)
 
 Temporarily unavailable: `@lidr/lidr-specboot` returns a 404 from the npm registry (not published, or published under a different name/scope). Use Option A for now — see [#6](https://github.com/LIDR-academy/lidr-specboot/issues/6) for status.

--- a/README.md
+++ b/README.md
@@ -84,22 +84,42 @@ Copy this repository into your project first, so the `docs/` and `ai-specs/` pat
 # Clone or copy this repository into your project (`-n`: do not overwrite existing files so you keep project's original README)
 cp -rn lidr-specboot/* your-project/
 ```
+<details>
+<summary><strong>Windows</strong>: <code>cp -rn</code> won't work — click for a working alternative</summary>
+
+`cp -rn` (and `tar`/`git archive`) cannot recreate the symlinks this repo relies on (`AGENTS.md`, `CLAUDE.md`, `.claude/agents/*`, `.claude/skills/*`, etc.). You'll get errors like `cp: cannot create symbolic link '...': No such file or directory`, and any skill/agent that depends on those links (e.g. `enrich-us`) won't be discovered.
+
+Only `git` itself can recreate symlinks on Windows, and only with both of these enabled first:
+- Developer Mode turned on (Settings → Privacy & Security → For developers)
+- `git config --global core.symlinks true`
+
+With those two set:
+
+1. **Clone specboot into a temporary folder inside your project** (not a plain copy) — this is what lets git recreate the symlinks correctly:
+   ```bash
+   cd your-project
+   git clone https://github.com/LIDR-academy/lidr-specboot.git lidr-specboot-tmp
+
+2. Copy the plain (non-symlink) content — docs/ and ai-specs/ — into your project:
+
+cp -rn lidr-specboot-tmp/docs your-project/
+cp -rn lidr-specboot-tmp/ai-specs your-project/
+
+3. Recreate each symlink Specboot ships (they don't survive step 2's plain cp), one per file/dir your copilot needs — from a Git Bash terminal:
+
+MSYS=winsymlinks:nativestrict ln -s docs/base-standards.md CLAUDE.md
+MSYS=winsymlinks:nativestrict ln -s docs/base-standards.md AGENTS.md
+MSYS=winsymlinks:nativestrict ln -s ../../ai-specs/agents/backend-developer.md .claude/agents/backend-developer.md
+
+4. Clean up the temporary clone: rm -rf lidr-specboot-tmp
+
+More manual than a single cp -rn, but it's the only reliable path on Windows today. See #6 for the full investigation.
+
+</details> 
 
 #### Option B (Claude Code users)
 
-If you use Claude Code, you can use the Specboot installer instead of copying the files manually.
-
-- It only changes **how** Specboot is imported into your project.
-- It does **not** install OpenSpec.
-- It does **not** update the OpenSpec configuration.
-- It does **not** customize `docs/`.
-
-Quick install - From the root directory of your project, open a terminal and run:
-```bash
-npx @lidr/lidr-specboot
-```
-
-This copies all files into your project and recreates the symlink structure automatically. Safe to re-run: existing files are never overwritten.
+Temporarily unavailable: `@lidr/lidr-specboot` returns a 404 from the npm registry (not published, or published under a different name/scope). Use Option A for now — see [#6](https://github.com/LIDR-academy/lidr-specboot/issues/6) for status.
 
 
 ### 3) Customize `docs/` for Your Project (Mandatory)


### PR DESCRIPTION
**Summary**

This PR clarifies the installation instructions in **Step 2** of the README by restructuring the section into two clearly labeled options (Manual and Claude Code), and adds concrete Windows installation guidance for Option A.

**Why**

The contributor noted confusion about whether the `npx` command should be used alongside Claude Code, as the Claude alternative appeared "sandwiched" between sequential steps. The updated wording removes ambiguity without altering the installation process itself.

Separately, Windows users following Option A hit a hard blocker: `cp -rn`/`tar`/`git archive` cannot recreate the symlinks this repo relies on (`AGENTS.md`, `CLAUDE.md`, agent/skill symlinks), so any copilot depending on those links can't discover skills like `enrich-us`. See #6 for the full investigation — the root cause is that only `git` can recreate symlinks on Windows, and only with Developer Mode + `core.symlinks=true` enabled.

Finally, a repo using Specboot was found to have dragged a stale copy of an OpenSpec CLI skill into Specboot's canonical `ai-specs/` namespace: `openspec init` writes the `openspec-*` skills (`author: openspec`) directly into the agent folders, and canonicalizing "everything under `.claude/skills`" without filtering by author pulls one of those into `ai-specs/`, where it goes orphaned — never executed and never refreshed by `openspec update`. Option A now warns against this explicitly.

**Changes**

- Rename the two installation paths as **Option A (Manual)** and **Option B (Claude Code users)**
- Add "Choose one of the following options." at the beginning of Step 2
- Add a collapsible "Windows" section under Option A with a working, step-by-step alternative (clone into a temp folder, copy `docs/`/`ai-specs/`, recreate symlinks with `MSYS=winsymlinks:nativestrict`)
- Add a note under Option A warning not to canonicalize OpenSpec's own `openspec-*` skills (`author: openspec`) into `ai-specs/`, since the CLI manages them directly and a copy there is never executed and silently drifts out of version
- Mark Option B as temporarily unavailable: `@lidr/lidr-specboot` currently 404s on the npm registry
- Documentation only; no functional changes

Fixes #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured the Quick Start import instructions into clear manual and Claude Code options.
  * Added expanded guidance for copying required directories and configuring OpenSpec.
  * Added Windows-specific instructions for recreating required symlinks.
  * Clarified how to handle OpenSpec-generated skills and validate author metadata.
  * Noted the temporary unavailability of the Claude Code installation option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
